### PR TITLE
duplicate Flex/on-demand trips

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,4 +5,5 @@ set -x
 
 generate-booking-rules-txt /app/herrenberg-flex-rules.js *.txt | tee booking_rules.txt | wc -l
 generate-locations-geojson /app/herrenberg-flex-rules.js *.txt | tee locations.geojson | wc -l
+patch-trips-txt /app/herrenberg-flex-rules.js *.txt | sponge trips.txt
 patch-stop-times-txt /app/herrenberg-flex-rules.js *.txt | sponge stop_times.txt

--- a/lib/ids.js
+++ b/lib/ids.js
@@ -4,6 +4,11 @@ const generateFlexLocationId = (flexSpecId, stopId) => {
 	return `${flexSpecId}-${stopId}-flex`
 }
 
+const generateFlexTripId = (originalTripId) => {
+	return `${originalTripId}-flex`
+}
+
 module.exports = {
 	generateFlexLocationId,
+	generateFlexTripId,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
 			"bin": {
 				"generate-booking-rules-txt": "gen-booking-rules-txt.js",
 				"generate-locations-geojson": "gen-locations-geojson.js",
-				"patch-stop-times-txt": "patch-stop-times-txt.js"
+				"patch-stop-times-txt": "patch-stop-times-txt.js",
+				"patch-trips-txt": "patch-trips-txt.js"
 			},
 			"devDependencies": {
 				"eslint": "^7.9.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"bin": {
 		"generate-locations-geojson": "gen-locations-geojson.js",
 		"generate-booking-rules-txt": "gen-booking-rules-txt.js",
+		"patch-trips-txt": "patch-trips-txt.js",
 		"patch-stop-times-txt": "patch-stop-times-txt.js"
 	},
 	"keywords": [

--- a/patch-trips-txt.js
+++ b/patch-trips-txt.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+'use strict'
+
+const mri = require('mri')
+const pkg = require('./package.json')
+
+const argv = mri(process.argv.slice(2), {
+	boolean: [
+		'help', 'h',
+		'version', 'v',
+	]
+})
+
+if (argv.help || argv.h) {
+	process.stdout.write(`
+Usage:
+    patch-trips-txt <path-to-flex-rules> <gtfs-routes> <gtfs-trips>
+Examples:
+    patch-trips-txt flex-rules.js \\
+        gtfs/{routes,trips,stops,stop_times}.txt >gtfs/trips.patched.txt
+\n`)
+	process.exit(0)
+}
+
+if (argv.version || argv.v) {
+	process.stdout.write(`${pkg.name} v${pkg.version}\n`)
+	process.exit(0)
+}
+
+const showError = (err) => {
+	console.error(err)
+	process.exit(1)
+}
+
+const {resolve} = require('path')
+const assert = require('assert')
+const pickupTypes = require('gtfs-utils/pickup-types')
+const dropOffTypes = require('gtfs-utils/drop-off-types')
+const {Stringifier} = require('csv-stringify')
+const createReadGtfsFile = require('./lib/read-gtfs-files')
+const addSeconds = require('./lib/add-seconds')
+const {computeFlexSpecsByRouteId} = require('./lib/flex-specs-by-trip-id')
+const {
+	generateFlexTripId: flexTripId,
+} = require('./lib/ids')
+
+const pathToFlexRules = argv._[0]
+if (!pathToFlexRules) showError('Missing path-to-flex-rules.')
+const flexRules = require(resolve(process.cwd(), pathToFlexRules))
+
+const requiredGtfsFiles = [
+	'routes',
+	'trips',
+]
+const readGtfsFile = createReadGtfsFile(requiredGtfsFiles, argv._.slice(1))
+
+;(async () => {
+	const byRouteId = await computeFlexSpecsByRouteId(flexRules, readGtfsFile)
+
+	const csv = new Stringifier({
+		quoted: true,
+		header: true,
+	})
+	csv.pipe(process.stdout)
+
+	// pass through all trips, create Flex duplicates
+	for await (const t of readGtfsFile('trips')) {
+		csv.write(t)
+
+		if (byRouteId.has(t.route_id)) {
+			// Flex/on-demand case, duplicate trip
+			const t2 = {
+				...t,
+				trip_id: flexTripId(t.trip_id),
+			}
+			csv.write(t2)
+		}
+	}
+
+	csv.end()
+})()
+.catch(showError)

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,10 @@ npm exec -- generate-booking-rules-txt \
 	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
 	vvs-gtfs/routes.txt \
 	>vvs-gtfs/booking_rules.txt
+npm exec -- patch-trips-txt \
+	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
+	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
+	| sponge vvs-gtfs/trips.txt
 npm exec -- patch-stop-times-txt \
 	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
 	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
@@ -69,11 +73,21 @@ Examples:
 
 ```
 Usage:
+    patch-trips-txt <path-to-flex-rules> <gtfs-routes> <gtfs-trips> <gtfs-stops> <gtfs-stop-times>
+Examples:
+    patch-trips-txt flex-rules.js \
+        gtfs/{routes,trips,stops,stop_times}.txt >gtfs/trips.patched.txt
+```
+
+```
+Usage:
     patch-stop-times-txt <path-to-flex-rules> <gtfs-routes> <gtfs-trips> <gtfs-stops> <gtfs-stop-times>
 Examples:
     patch-stop-times-txt flex-rules.js \
         gtfs/{routes,trips,stops,stop_times}.txt >gtfs/stop_times.patched.txt
 ```
+
+*Note:* Currently, this tool *duplicates* all trips & `stop_times` rows affected by one of the rules: One on-demand trip stopping directly at the stops, one trip stopping at Flex areas.
 
 ### with Docker
 
@@ -139,6 +153,9 @@ npm exec -- generate-locations-geojson \
 npm exec -- generate-booking-rules-txt \
 	flex-rules.js gtfs/routes.txt \
 	>gtfs/booking_rules.txt
+npm exec -- patch-trips-txt \
+	flex-rules.js gtfs/{routes,trips,stops,stop_times}.txt \
+	| sponge gtfs/trips.txt
 npm exec -- patch-stop-times-txt \
 	flex-rules.js gtfs/{routes,trips,stops,stop_times}.txt \
 	| sponge gtfs/stop_times.txt


### PR DESCRIPTION
> We have tried running with the data generated by [...] #1, but it seems that OTP2 doesn't like it either.

https://github.com/derhuerst/generate-herrenberg-gtfs-flex/pull/1#issuecomment-848781374

This PR makes `generate-herrenberg-gtfs-flex` *duplicate* the entire non-flex trip (including its `stop_times.txt` rows), into a flex trip.

- [x] add GTFS-BookingRules to `stop_times.txt` rows of *non-duplicated* trips

---

this PR conflicts with #1, as having both doesn't make sense