### PR TITLE
support bbnavi

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14', '16']
+        node-version: ['16']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           push: true
           tags: |
-            derhuerst/generate-herrenberg-gtfs-flex:latest
+            derhuerst/generate-gtfs-flex:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,3 +39,4 @@ jobs:
           push: true
           tags: |
             derhuerst/generate-gtfs-flex:latest
+            derhuerst/generate-gtfs-flex:4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:alpine
 LABEL org.opencontainers.image.title="generate-herrenberg-gtfs-flex"
-LABEL org.opencontainers.image.description="Generate GTFS Flex for Herrenberg on-demand public transport service."
+LABEL org.opencontainers.image.description="Given a GTFS Static feed, add GTFS Flex v2 to model on-demand public transport service."
 LABEL org.opencontainers.image.authors="Jannis R <mail@jannisr.de>"
 LABEL org.opencontainers.image.documentation="https://github.com/derhuerst/generate-herrenberg-gtfs-flex"
 LABEL org.opencontainers.image.source="https://github.com/derhuerst/generate-herrenberg-gtfs-flex"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:alpine
-LABEL org.opencontainers.image.title="generate-herrenberg-gtfs-flex"
+FROM node:lts-alpine
+LABEL org.opencontainers.image.title="generate-gtfs-flex"
 LABEL org.opencontainers.image.description="Given a GTFS Static feed, add GTFS Flex v2 to model on-demand public transport service."
 LABEL org.opencontainers.image.authors="Jannis R <mail@jannisr.de>"
-LABEL org.opencontainers.image.documentation="https://github.com/derhuerst/generate-herrenberg-gtfs-flex"
-LABEL org.opencontainers.image.source="https://github.com/derhuerst/generate-herrenberg-gtfs-flex"
+LABEL org.opencontainers.image.documentation="https://github.com/derhuerst/generate-gtfs-flex"
+LABEL org.opencontainers.image.source="https://github.com/derhuerst/generate-gtfs-flex"
 LABEL org.opencontainers.image.licenses="ISC"
 
 WORKDIR /app

--- a/bbnavi-flex-rules.js
+++ b/bbnavi-flex-rules.js
@@ -1,0 +1,42 @@
+'use strict'
+
+// These are the GTFS-Flex patching rules used by bbnavi (https://bbnavi.de).
+
+const pickupTypes = require('gtfs-utils/pickup-types')
+const dropOffTypes = require('gtfs-utils/drop-off-types')
+const bookingTypes = require('gtfs-utils/booking-types')
+
+const uvgLinienrufbusFlexSpec = {
+	id: 'uvg-linienrufbus',
+	pickup_type: pickupTypes.MUST_PHONE_AGENCY,
+	drop_off_type: dropOffTypes.MUST_COORDINATE_WITH_DRIVER,
+	bookingRule: {
+		booking_rule_id: 'uvg-linienrufbus',
+		booking_type: bookingTypes.SAME_DAY,
+		prior_notice_duration_min: 60,
+		message: `\
+Anmeldung bis 60min vor Abfahrt, per Telefon (täglich von 08:00-24:00) oder online.`,
+		phone_number: '+49 3332 442 755',
+		// todo: separate flex specs for Angermünde & Gartz?
+		// https://uvg-online.com/rufbus-angermuende/
+		// https://uvg-online.com/rufbus-gartz/
+		info_url: 'https://uvg-online.com/rufbus/',
+	},
+}
+const uvgLinienrufbusRoutes = [
+	'459',
+	// todo: there are more
+]
+const uvgLinienrufbus = (origTrip, origRoute) => (
+	// todo: how do we distinguish Rufbus trips from regular trips?
+	// currently neither the DELFI GTFS nor the VBB GTFS provide a discerning field
+	uvgLinienrufbusRoutes.includes(origRoute.route_short_name)
+		? uvgLinienrufbusFlexSpec
+		: null
+)
+
+const bbnaviFlexRules = [
+	uvgLinienrufbus,
+]
+
+module.exports = bbnaviFlexRules

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,6 +36,6 @@ set -x
 
 generate-booking-rules-txt "$rules_file" *.txt | tee booking_rules.txt | wc -l
 generate-locations-geojson "$rules_file" *.txt | tee locations.geojson | wc -l
-patch-routes-txt "$rules_file" routes.txt | sponge routes.txt
+patch-routes-txt "$rules_file" {routes,trips}.txt | sponge routes.txt
 patch-trips-txt "$rules_file" *.txt | sponge trips.txt
 patch-stop-times-txt "$rules_file" *.txt | sponge stop_times.txt

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,26 +2,40 @@
 set -e
 set -o pipefail
 
-if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
-	1>&2 cat << EOF
+usage="$(
+	cat << EOF
 usage:
-	docker run … [gtfs-directory]
+	docker run … <rules-file> [gtfs-directory]
 example:
-	docker run -v \$PWD/data:/gtfs derhuerst/generate-gtfs-flex
-	docker run -v \$PWD/data:/data derhuerst/generate-gtfs-flex /data
+	docker run -v \$PWD/data:/gtfs derhuerst/generate-gtfs-flex stadtnavi-herrenberg-rules.js
+	docker run -v \$PWD/cfg:/cfg -v \$PWD/data:/data derhuerst/generate-gtfs-flex /cfg/rules.js /data
 EOF
+)"
+if [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
+	1>&2 echo "$usage"
 	exit 0
 fi
 
-if [ -n "$1" ]; then
-	1>&2 echo "running inside $1"
-	cd "$1"
+pushd .
+cd "$(dirname $0)"
+rules_file="$1"
+if [ -z "$rules_file" ]; then
+	1>&2 echo -e "missing/empty 1st argument: rules-file\n"
+	1>&2 echo "$usage"
+	exit 1
+fi
+rules_file="$(realpath "$1")"
+popd
+
+if [ -n "$2" ]; then
+	1>&2 echo "running inside $(realpath "$2")"
+	cd "$2"
 fi
 
 set -x
 
-generate-booking-rules-txt /app/herrenberg-flex-rules.js *.txt | tee booking_rules.txt | wc -l
-generate-locations-geojson /app/herrenberg-flex-rules.js *.txt | tee locations.geojson | wc -l
-patch-routes-txt /app/herrenberg-flex-rules.js routes.txt | sponge routes.txt
-patch-trips-txt /app/herrenberg-flex-rules.js *.txt | sponge trips.txt
-patch-stop-times-txt /app/herrenberg-flex-rules.js *.txt | sponge stop_times.txt
+generate-booking-rules-txt "$rules_file" *.txt | tee booking_rules.txt | wc -l
+generate-locations-geojson "$rules_file" *.txt | tee locations.geojson | wc -l
+patch-routes-txt "$rules_file" routes.txt | sponge routes.txt
+patch-trips-txt "$rules_file" *.txt | sponge trips.txt
+patch-stop-times-txt "$rules_file" *.txt | sponge stop_times.txt

--- a/gen-locations-geojson.js
+++ b/gen-locations-geojson.js
@@ -70,9 +70,13 @@ const readGtfsFile = createReadGtfsFile(requiredGtfsFiles, argv._.slice(1))
 	for (const [trip_id, spec] of byTripId) {
 		const {
 			id: specId,
-			radius,
 			stops,
 		} = spec
+
+		// skip flex specs without geographic buffer
+		if (!('radius' in spec)) continue
+		const radius = spec.radius
+
 		for (const s of stops) {
 			const locId = flexLocId(specId, s.stop_id)
 			if (printedLocs.has(locId)) continue

--- a/lib/booking-rules.js
+++ b/lib/booking-rules.js
@@ -5,10 +5,18 @@ const validateFlexSpec = require('./validate-flex-spec')
 const computeAllBookingRules = async (flexRules, readGtfsFile) => {
 	const bookingRulesById = new Map() // booking_rule_id -> booking rule
 
+	const routes = new Map() // route_id -> route
 	for await (const r of await readGtfsFile('routes')) {
+		routes.set(r.route_id, r)
+	}
+
+	for await (const t of await readGtfsFile('trips')) {
+		if (!routes.has(t.route_id)) continue
+		const route = routes.get(t.route_id)
+
 		// find any matching GTFS-Flex rule
 		for (const flexRule of flexRules) {
-			const flexSpec = flexRule(r)
+			const flexSpec = flexRule(t, route)
 			if (flexSpec) {
 				validateFlexSpec(flexSpec)
 				const {bookingRule} = flexSpec

--- a/lib/booking-rules.js
+++ b/lib/booking-rules.js
@@ -5,7 +5,7 @@ const validateFlexSpec = require('./validate-flex-spec')
 const computeAllBookingRules = async (flexRules, readGtfsFile) => {
 	const bookingRulesById = new Map() // booking_rule_id -> booking rule
 
-	for await (const r of readGtfsFile('routes')) {
+	for await (const r of await readGtfsFile('routes')) {
 		// find any matching GTFS-Flex rule
 		for (const flexRule of flexRules) {
 			const flexSpec = flexRule(r)

--- a/lib/flex-spec-schema.json
+++ b/lib/flex-spec-schema.json
@@ -7,7 +7,6 @@
 			"type": "object",
 			"required": [
 				"id",
-				"radius",
 				"pickup_type",
 				"drop_off_type",
 				"bookingRule"

--- a/lib/flex-specs-by-trip-id.js
+++ b/lib/flex-specs-by-trip-id.js
@@ -5,7 +5,7 @@ const validateFlexSpec = require('./validate-flex-spec')
 const computeFlexSpecsByRouteId = async (flexRules, readGtfsFile) => {
 	const flexSpecsByRouteId = new Map() // route_id -> GTFS-Flex spec
 
-	for await (const r of readGtfsFile('routes')) {
+	for await (const r of await readGtfsFile('routes')) {
 		// find any matching GTFS-Flex rule
 		for (const flexRule of flexRules) {
 			const flexSpec = flexRule(r)
@@ -24,7 +24,7 @@ const computeFlexSpecsByTripId = async (flexRules, readGtfsFile) => {
 	const byRouteId = await computeFlexSpecsByRouteId(flexRules, readGtfsFile)
 
 	const byTripId = new Map()
-	for await (const t of readGtfsFile('trips')) {
+	for await (const t of await readGtfsFile('trips')) {
 		if (byRouteId.has(t.route_id)) {
 			const flexSpec = byRouteId.get(t.route_id)
 			byTripId.set(t.trip_id, flexSpec)
@@ -45,11 +45,11 @@ const computeFlexSpecsWithStopsByTripId = async (flexRules, readGtfsFile) => {
 	}
 
 	const allStops = new Map()
-	for await (const s of readGtfsFile('stops')) {
+	for await (const s of await readGtfsFile('stops')) {
 		allStops.set(s.stop_id, s)
 	}
 
-	for await (const st of readGtfsFile('stop_times')) {
+	for await (const st of await readGtfsFile('stop_times')) {
 		if (!withStopsByTripId.has(st.trip_id)) continue
 		if (!allStops.has(st.stop_id)) continue
 

--- a/lib/flex-specs-by-trip-id.js
+++ b/lib/flex-specs-by-trip-id.js
@@ -1,33 +1,27 @@
 'use strict'
 
+
 const validateFlexSpec = require('./validate-flex-spec')
 
-const computeFlexSpecsByRouteId = async (flexRules, readGtfsFile) => {
-	const flexSpecsByRouteId = new Map() // route_id -> GTFS-Flex spec
-
+const computeFlexSpecsByTripId = async (flexRules, readGtfsFile) => {
+	const routes = new Map() // route_id -> route
 	for await (const r of await readGtfsFile('routes')) {
-		// find any matching GTFS-Flex rule
-		for (const flexRule of flexRules) {
-			const flexSpec = flexRule(r)
-			if (flexSpec) {
-				validateFlexSpec(flexSpec)
-				flexSpecsByRouteId.set(r.route_id, flexSpec)
-				break
-			}
-		}
+		routes.set(r.route_id, r)
 	}
 
-	return flexSpecsByRouteId
-}
-
-const computeFlexSpecsByTripId = async (flexRules, readGtfsFile) => {
-	const byRouteId = await computeFlexSpecsByRouteId(flexRules, readGtfsFile)
-
-	const byTripId = new Map()
+	const byTripId = new Map() // trip_id -> [flexSpec, route]
 	for await (const t of await readGtfsFile('trips')) {
-		if (byRouteId.has(t.route_id)) {
-			const flexSpec = byRouteId.get(t.route_id)
-			byTripId.set(t.trip_id, flexSpec)
+		if (!routes.has(t.route_id)) continue
+		const route = routes.get(t.route_id)
+
+		// find any matching GTFS-Flex rule
+		for (const flexRule of flexRules) {
+			const flexSpec = flexRule(t, route)
+			if (flexSpec) {
+				validateFlexSpec(flexSpec)
+				byTripId.set(t.trip_id, [flexSpec, route])
+				break
+			}
 		}
 	}
 
@@ -36,10 +30,12 @@ const computeFlexSpecsByTripId = async (flexRules, readGtfsFile) => {
 
 const computeFlexSpecsWithStopsByTripId = async (flexRules, readGtfsFile) => {
 	const byTripId = await computeFlexSpecsByTripId(flexRules, readGtfsFile)
+
 	const withStopsByTripId = new Map()
-	for (const [tripId, flexSpec] of byTripId.entries()) {
+	for (const [tripId, [flexSpec, route]] of byTripId.entries()) {
 		withStopsByTripId.set(tripId, {
 			...flexSpec,
+			route,
 			stops: new Set(),
 		})
 	}
@@ -61,7 +57,6 @@ const computeFlexSpecsWithStopsByTripId = async (flexRules, readGtfsFile) => {
 }
 
 module.exports = {
-	computeFlexSpecsByRouteId,
 	computeFlexSpecsByTripId,
 	computeFlexSpecsWithStopsByTripId,
 }

--- a/lib/read-gtfs-files.js
+++ b/lib/read-gtfs-files.js
@@ -10,7 +10,14 @@ const createReadGtfsFile = (requiredFiles, gtfsFilePaths) => {
 		gtfsFiles[name] = path
 	}
 
-	const missingFileErr = name => new Error(`missing ${name}.txt file`)
+	const missingFileErr = (name) => {
+		const err = new Error(`missing ${name}.txt file`)
+		err.code = 'ENOENT'
+		err.notFound = true
+		err.statusCode === 404
+		return err
+	}
+
 	for (const name of requiredFiles) {
 		if (!gtfsFiles[name]) throw missingFileErr(name)
 	}

--- a/lib/read-gtfs-files.js
+++ b/lib/read-gtfs-files.js
@@ -15,9 +15,9 @@ const createReadGtfsFile = (requiredFiles, gtfsFilePaths) => {
 		if (!gtfsFiles[name]) throw missingFileErr(name)
 	}
 
-	const readGtfsFile = (name) => {
+	const readGtfsFile = async (name) => {
 		if (!gtfsFiles[name]) throw missingFileErr(name)
-		return readCsv(gtfsFiles[name])
+		return await readCsv(gtfsFiles[name])
 	}
 	return readGtfsFile
 }

--- a/lib/validate-flex-spec.js
+++ b/lib/validate-flex-spec.js
@@ -34,6 +34,8 @@ Haustürbedienung beim Absetzen 300m (Luftlinie) um die Haltestelle. Aufpreis 0,
 	},
 }
 
+// todo: add a bbnavi flex spec
+
 doesNotThrow(() => {
 	validateFlexSpec(herrenbergCitybus)
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"ajv": "^8.6.1",
 				"csv-parser": "^3.0.0",
 				"csv-stringify": "^5.6.5",
-				"gtfs-utils": "^4.2.0",
+				"gtfs-utils": "^5.0.0",
 				"mri": "^1.1.6"
 			},
 			"bin": {
@@ -29,7 +29,7 @@
 				"sample-gtfs-feed": "^0.10.3"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -103,6 +103,30 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"node_modules/@turf/bbox": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+			"integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/@turf/bearing": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+			"integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
 		"node_modules/@turf/circle": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.5.0.tgz",
@@ -119,6 +143,18 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.5.0.tgz",
 			"integrity": "sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/@turf/distance": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+			"integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
 			"dependencies": {
 				"@turf/helpers": "^6.5.0",
 				"@turf/invariant": "^6.5.0"
@@ -146,6 +182,34 @@
 				"url": "https://opencollective.com/turf"
 			}
 		},
+		"node_modules/@turf/line-intersect": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
+			"integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/line-segment": "^6.5.0",
+				"@turf/meta": "^6.5.0",
+				"geojson-rbush": "3.x"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
+		"node_modules/@turf/line-segment": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
+			"integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
+			"dependencies": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/turf"
+			}
+		},
 		"node_modules/@turf/meta": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
@@ -168,6 +232,11 @@
 			"funding": {
 				"url": "https://opencollective.com/turf"
 			}
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.8",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+			"integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
 		},
 		"node_modules/acorn": {
 			"version": "8.7.0",
@@ -662,6 +731,18 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
+		"node_modules/geojson-rbush": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
+			"integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
+			"dependencies": {
+				"@turf/bbox": "*",
+				"@turf/helpers": "6.x",
+				"@turf/meta": "6.x",
+				"@types/geojson": "7946.0.8",
+				"rbush": "^3.0.1"
+			}
+		},
 		"node_modules/glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -710,24 +791,28 @@
 			}
 		},
 		"node_modules/gtfs-utils": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/gtfs-utils/-/gtfs-utils-4.3.2.tgz",
-			"integrity": "sha512-7CSMw1yziHruL23AKWqnN0lP/PQyMJyZuH4qIzlF9B7AzGImxlNe76N+MwqKrs91sY+2ATb6tm6PlQzExTSnxQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gtfs-utils/-/gtfs-utils-5.0.0.tgz",
+			"integrity": "sha512-OOb7Ai1AAVQrBZlvHdzepp2lB2ziVJcJn6xZOBQzQ5KFuBzYK8rCzd7GU5bRRmehhEaIHaVhz6kK6TteNvuUQQ==",
 			"dependencies": {
+				"@turf/bearing": "^6.3.0",
+				"@turf/destination": "^6.3.0",
+				"@turf/distance": "^6.3.0",
+				"@turf/line-intersect": "^6.3.0",
 				"csv-parser": "^3.0.0",
 				"date-fns": "^2.12.0",
 				"date-fns-tz": "^1.0.10",
 				"debug": "^4.1.1",
 				"ioredis": "^4.17.3",
 				"is-stream": "^2.0.0",
-				"luxon": "^1.0.0",
+				"luxon": "^2.3.0",
 				"quick-lru": "^5.1.1",
 				"shorthash": "0.0.2",
 				"sorted-array-functions": "^1.2.0",
 				"strip-bom-stream": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			}
 		},
 		"node_modules/has-flag": {
@@ -915,11 +1000,11 @@
 			"dev": true
 		},
 		"node_modules/luxon": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-			"integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+			"integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg==",
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			}
 		},
 		"node_modules/minimatch": {
@@ -1048,6 +1133,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/quickselect": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+			"integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+		},
+		"node_modules/rbush": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+			"integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+			"dependencies": {
+				"quickselect": "^2.0.0"
 			}
 		},
 		"node_modules/redis-commands": {
@@ -1361,6 +1459,24 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"@turf/bbox": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+			"integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			}
+		},
+		"@turf/bearing": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+			"integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			}
+		},
 		"@turf/circle": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.5.0.tgz",
@@ -1379,6 +1495,15 @@
 				"@turf/invariant": "^6.5.0"
 			}
 		},
+		"@turf/distance": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+			"integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			}
+		},
 		"@turf/helpers": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
@@ -1390,6 +1515,28 @@
 			"integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
 			"requires": {
 				"@turf/helpers": "^6.5.0"
+			}
+		},
+		"@turf/line-intersect": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
+			"integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/line-segment": "^6.5.0",
+				"@turf/meta": "^6.5.0",
+				"geojson-rbush": "3.x"
+			}
+		},
+		"@turf/line-segment": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
+			"integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/meta": "^6.5.0"
 			}
 		},
 		"@turf/meta": {
@@ -1408,6 +1555,11 @@
 				"@turf/helpers": "^6.5.0",
 				"@turf/meta": "^6.5.0"
 			}
+		},
+		"@types/geojson": {
+			"version": "7946.0.8",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+			"integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
 		},
 		"acorn": {
 			"version": "8.7.0",
@@ -1777,6 +1929,18 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
+		"geojson-rbush": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
+			"integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
+			"requires": {
+				"@turf/bbox": "*",
+				"@turf/helpers": "6.x",
+				"@turf/meta": "6.x",
+				"@types/geojson": "7946.0.8",
+				"rbush": "^3.0.1"
+			}
+		},
 		"glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -1810,17 +1974,21 @@
 			}
 		},
 		"gtfs-utils": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/gtfs-utils/-/gtfs-utils-4.3.2.tgz",
-			"integrity": "sha512-7CSMw1yziHruL23AKWqnN0lP/PQyMJyZuH4qIzlF9B7AzGImxlNe76N+MwqKrs91sY+2ATb6tm6PlQzExTSnxQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/gtfs-utils/-/gtfs-utils-5.0.0.tgz",
+			"integrity": "sha512-OOb7Ai1AAVQrBZlvHdzepp2lB2ziVJcJn6xZOBQzQ5KFuBzYK8rCzd7GU5bRRmehhEaIHaVhz6kK6TteNvuUQQ==",
 			"requires": {
+				"@turf/bearing": "^6.3.0",
+				"@turf/destination": "^6.3.0",
+				"@turf/distance": "^6.3.0",
+				"@turf/line-intersect": "^6.3.0",
 				"csv-parser": "^3.0.0",
 				"date-fns": "^2.12.0",
 				"date-fns-tz": "^1.0.10",
 				"debug": "^4.1.1",
 				"ioredis": "^4.17.3",
 				"is-stream": "^2.0.0",
-				"luxon": "^1.0.0",
+				"luxon": "^2.3.0",
 				"quick-lru": "^5.1.1",
 				"shorthash": "0.0.2",
 				"sorted-array-functions": "^1.2.0",
@@ -1972,9 +2140,9 @@
 			"dev": true
 		},
 		"luxon": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-			"integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+			"integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg=="
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -2070,6 +2238,19 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
 			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+		},
+		"quickselect": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+			"integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+		},
+		"rbush": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+			"integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+			"requires": {
+				"quickselect": "^2.0.0"
+			}
 		},
 		"redis-commands": {
 			"version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "generate-herrenberg-gtfs-flex",
+	"name": "generate-gtfs-flex",
 	"version": "3.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "generate-herrenberg-gtfs-flex",
+			"name": "generate-gtfs-flex",
 			"version": "3.0.1",
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "generate-gtfs-flex",
-	"version": "3.0.1",
+	"version": "4.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "generate-gtfs-flex",
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"license": "ISC",
 			"dependencies": {
 				"@turf/circle": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"private": true,
-	"name": "generate-herrenberg-gtfs-flex",
+	"name": "generate-gtfs-flex",
 	"description": "Generate GTFS Flex for Herrenberg on-demand public transport service.",
 	"version": "3.0.1",
 	"bin": {
@@ -17,9 +17,9 @@
 		"gtfs-flex"
 	],
 	"author": "Jannis R <mail@jannisr.de>",
-	"homepage": "https://github.com/derhuerst/generate-herrenberg-gtfs-flex",
-	"repository": "derhuerst/generate-herrenberg-gtfs-flex",
-	"bugs": "https://github.com/derhuerst/generate-herrenberg-gtfs-flex/issues",
+	"homepage": "https://github.com/derhuerst/generate-gtfs-flex",
+	"repository": "derhuerst/generate-gtfs-flex",
+	"bugs": "https://github.com/derhuerst/generate-gtfs-flex/issues",
 	"license": "ISC",
 	"engines": {
 		"node": ">=14"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"bugs": "https://github.com/derhuerst/generate-gtfs-flex/issues",
 	"license": "ISC",
 	"engines": {
-		"node": ">=14"
+		"node": ">=16"
 	},
 	"dependencies": {
 		"@turf/circle": "^6.5.0",
@@ -30,7 +30,7 @@
 		"ajv": "^8.6.1",
 		"csv-parser": "^3.0.0",
 		"csv-stringify": "^5.6.5",
-		"gtfs-utils": "^4.2.0",
+		"gtfs-utils": "^5.0.0",
 		"mri": "^1.1.6"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"name": "generate-gtfs-flex",
 	"description": "Generate GTFS Flex for Herrenberg on-demand public transport service.",
-	"version": "3.0.1",
+	"version": "4.0.0",
 	"bin": {
 		"generate-locations-geojson": "gen-locations-geojson.js",
 		"generate-booking-rules-txt": "gen-booking-rules-txt.js",

--- a/patch-routes-txt.js
+++ b/patch-routes-txt.js
@@ -34,11 +34,7 @@ const showError = (err) => {
 const {resolve} = require('path')
 const {Stringifier} = require('csv-stringify')
 const createReadGtfsFile = require('./lib/read-gtfs-files')
-// const addSeconds = require('./lib/add-seconds')
 const {computeFlexSpecsByTripId} = require('./lib/flex-specs-by-trip-id')
-// const {
-// 	generateFlexTripId: flexTripId,
-// } = require('./lib/ids')
 
 // https://developers.google.com/transit/gtfs/reference/extended-route-types
 const DEMAND_AND_RESPONSE_BUS = 715

--- a/patch-routes-txt.js
+++ b/patch-routes-txt.js
@@ -62,7 +62,7 @@ const readGtfsFile = createReadGtfsFile(requiredGtfsFiles, argv._.slice(1))
 	csv.pipe(process.stdout)
 
 	// pass through all routes, patch Flex routes as on-demand
-	for await (const t of readGtfsFile('routes')) {
+	for await (const t of await readGtfsFile('routes')) {
 		if (byRouteId.has(t.route_id)) {
 			t.route_type = DEMAND_AND_RESPONSE_BUS
 		}

--- a/patch-stop-times-txt.js
+++ b/patch-stop-times-txt.js
@@ -154,7 +154,7 @@ rufbusSpec ${specId} has a drop_off_type of ${drop_off_type}, but it is forbidde
 	const flexTrips = new Map()
 
 	// pass through all stop_times rows, but add booking rules & empty columns
-	for await (const st of readGtfsFile('stop_times')) {
+	for await (const st of await readGtfsFile('stop_times')) {
 		// Assume non-on-demand case first.
 		st.pickup_booking_rule_id = null
 		st.drop_off_booking_rule_id = null

--- a/patch-stop-times-txt.js
+++ b/patch-stop-times-txt.js
@@ -163,7 +163,7 @@ rufbusSpec ${specId} has a drop_off_type of ${drop_off_type}, but it is forbidde
 		st.timepoint = timepointTypes.EXACT
 
 		if (byTripId.has(st.trip_id)) {
-			const flexSpec = byTripId.get(st.trip_id)
+			const [flexSpec] = byTripId.get(st.trip_id)
 			patchStopTimeWithBookingRules(st, flexSpec)
 
 			if (!flexTrips.has(st.trip_id)) {
@@ -177,7 +177,7 @@ rufbusSpec ${specId} has a drop_off_type of ${drop_off_type}, but it is forbidde
 	}
 
 	for (let [originalTripId, stopTimes] of flexTrips.entries()) {
-		const flexSpec = byTripId.get(originalTripId)
+		const [flexSpec] = byTripId.get(originalTripId)
 		const flexTripId = genFlexTripId(originalTripId)
 
 		stopTimes = stopTimes

--- a/patch-trips-txt.js
+++ b/patch-trips-txt.js
@@ -39,7 +39,7 @@ const dropOffTypes = require('gtfs-utils/drop-off-types')
 const {Stringifier} = require('csv-stringify')
 const createReadGtfsFile = require('./lib/read-gtfs-files')
 const addSeconds = require('./lib/add-seconds')
-const {computeFlexSpecsByRouteId} = require('./lib/flex-specs-by-trip-id')
+const {computeFlexSpecsByTripId} = require('./lib/flex-specs-by-trip-id')
 const {
 	generateFlexTripId: flexTripId,
 } = require('./lib/ids')
@@ -55,7 +55,7 @@ const requiredGtfsFiles = [
 const readGtfsFile = createReadGtfsFile(requiredGtfsFiles, argv._.slice(1))
 
 ;(async () => {
-	const byRouteId = await computeFlexSpecsByRouteId(flexRules, readGtfsFile)
+	const byTripId = await computeFlexSpecsByTripId(flexRules, readGtfsFile)
 
 	const csv = new Stringifier({
 		quoted: true,
@@ -67,7 +67,7 @@ const readGtfsFile = createReadGtfsFile(requiredGtfsFiles, argv._.slice(1))
 	for await (const t of await readGtfsFile('trips')) {
 		csv.write(t)
 
-		if (byRouteId.has(t.route_id)) {
+		if (byTripId.has(t.trip_id)) {
 			// Flex/on-demand case, duplicate trip
 			const t2 = {
 				...t,

--- a/patch-trips-txt.js
+++ b/patch-trips-txt.js
@@ -64,7 +64,7 @@ const readGtfsFile = createReadGtfsFile(requiredGtfsFiles, argv._.slice(1))
 	csv.pipe(process.stdout)
 
 	// pass through all trips, create Flex duplicates
-	for await (const t of readGtfsFile('trips')) {
+	for await (const t of await readGtfsFile('trips')) {
 		csv.write(t)
 
 		if (byRouteId.has(t.route_id)) {

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ Given a [GTFS Static](https://gtfs.org/reference/static) feed, **add [GTFS Flex 
 
 [![ISC-licensed](https://img.shields.io/github/license/derhuerst/generate-herrenberg-gtfs-flex.svg)](license.md)
 
+This tool has originally developed for [Stadtnavi Herrenberg](https://herrenberg.stadtnavi.de), but it is used by other projects as well.
+
 *Note:* In order to get the behaviour we want (pickup only at stops but flexible drop-off within 300m), **we currently don't follow the spec as intended**; See [#5](https://github.com/derhuerst/generate-herrenberg-gtfs-flex/issues/5) and [#6](https://github.com/derhuerst/generate-herrenberg-gtfs-flex/pull/6) for details.
 
 
@@ -18,9 +20,13 @@ docker pull derhuerst/generate-herrenberg-gtfs-flex
 
 ## Getting started
 
-The scripts in this repo are written to be used with any GTFS feed. But there's also a file [`herrenberg-flex-rules.js`](herrenberg-flex-rules.js), which specifies the on-demand lines in [Herrenberg, Germany](https://en.wikipedia.org/wiki/Herrenberg) (part of [VVS](https://www.vvs.de)).
+The scripts in this repo are written to be used with any GTFS feed; They need a *rule file* that describes which GTFS Static routes to patch with GTFS Flex information.
 
-The following steps will demonstrate how to use the scripts with `herrenberg-flex-rules.js`, in order to patch the [VVS GTFS feed](https://www.openvvs.de/dataset/e66f03e4-79f2-41d0-90f1-166ca609e491) with GTFS-Flex data. You must have [Node.js](https://nodejs.org/) installed (which includes the [`npm` CLI](https://docs.npmjs.com/cli/v7)).
+In addition, there are *rule files* for some projects that use this tool:
+
+- [`stadtnavi-herrenberg-flex-rules.js`](stadtnavi-herrenberg-flex-rules.js) – specifies the on-demand lines in [Herrenberg, Germany](https://en.wikipedia.org/wiki/Herrenberg) (part of [VVS](https://www.vvs.de)), used by [Stadtnavi Herrenberg](https://herrenberg.stadtnavi.de).
+
+The following steps will demonstrate how to use `generate-herrenberg-gtfs-flex` with `stadtnavi-herrenberg-flex-rules.js`. You must have [Node.js](https://nodejs.org/) installed (which includes the [`npm` CLI](https://docs.npmjs.com/cli/v7)).
 
 ```bash
 # set up an empty npm project
@@ -38,23 +44,23 @@ npm install --save-dev derhuerst/generate-herrenberg-gtfs-flex
 
 # patch GTFS-Flex data into the VVS GTFS feed
 ./node_modules/.bin/generate-locations-geojson \
-	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
+	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
 	>vvs-gtfs/locations.geojson
 ./node_modules/.bin/generate-booking-rules-txt \
-	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
+	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/routes.txt \
 	>vvs-gtfs/booking_rules.txt
 ./node_modules/.bin/patch-trips-txt \
-	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
+	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
 	| sponge vvs-gtfs/trips.txt
 ./node_modules/.bin/patch-routes-txt \
-	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
+	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/routes.txt \
 	| sponge vvs-gtfs/routes.txt
 ./node_modules/.bin/patch-stop-times-txt \
-	node_modules/generate-herrenberg-gtfs-flex/herrenberg-flex-rules.js \
+	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
 	| sponge vvs-gtfs/stop_times.txt
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,20 @@
-# generate-herrenberg-gtfs-flex
+# generate-gtfs-flex
 
 Given a [GTFS Static](https://gtfs.org/reference/static) feed, **add [GTFS Flex v2](https://github.com/MobilityData/gtfs-flex/blob/e1832cfea5ddb9df29bd2fc50e80b0a4987695c1/spec/reference.md) to model on-demand public transport service.**
 
-[![ISC-licensed](https://img.shields.io/github/license/derhuerst/generate-herrenberg-gtfs-flex.svg)](license.md)
+[![ISC-licensed](https://img.shields.io/github/license/derhuerst/generate-gtfs-flex.svg)](license.md)
 
 This tool has originally developed for [Stadtnavi Herrenberg](https://herrenberg.stadtnavi.de), but it is used by other projects as well.
 
-*Note:* In order to get the behaviour we want (pickup only at stops but flexible drop-off within 300m), **we currently don't follow the spec as intended**; See [#5](https://github.com/derhuerst/generate-herrenberg-gtfs-flex/issues/5) and [#6](https://github.com/derhuerst/generate-herrenberg-gtfs-flex/pull/6) for details.
+*Note:* In order to get the behaviour we want (pickup only at stops but flexible drop-off within 300m), **we currently don't follow the spec as intended**; See [#5](https://github.com/derhuerst/generate-gtfs-flex/issues/5) and [#6](https://github.com/derhuerst/generate-gtfs-flex/pull/6) for details.
 
 
 ## Installation
 
 ```shell
-npm install derhuerst/generate-herrenberg-gtfs-flex
+npm install derhuerst/generate-gtfs-flex
 # or
-docker pull derhuerst/generate-herrenberg-gtfs-flex
+docker pull derhuerst/generate-gtfs-flex
 ```
 
 
@@ -26,7 +26,7 @@ In addition, there are *rule files* for some projects that use this tool:
 
 - [`stadtnavi-herrenberg-flex-rules.js`](stadtnavi-herrenberg-flex-rules.js) – specifies the on-demand lines in [Herrenberg, Germany](https://en.wikipedia.org/wiki/Herrenberg) (part of [VVS](https://www.vvs.de)), used by [Stadtnavi Herrenberg](https://herrenberg.stadtnavi.de).
 
-The following steps will demonstrate how to use `generate-herrenberg-gtfs-flex` with `stadtnavi-herrenberg-flex-rules.js`. You must have [Node.js](https://nodejs.org/) installed (which includes the [`npm` CLI](https://docs.npmjs.com/cli/v7)).
+The following steps will demonstrate how to use `generate-gtfs-flex` with `stadtnavi-herrenberg-flex-rules.js`. You must have [Node.js](https://nodejs.org/) installed (which includes the [`npm` CLI](https://docs.npmjs.com/cli/v7)).
 
 ```bash
 # set up an empty npm project
@@ -39,33 +39,33 @@ npm init --yes
 wget 'https://www.opendata-oepnv.de/dataset/d1768457-c717-45ea-8e26-dd1e759d5ffe/resource/ebc2eaae-9a03-4ace-8df7-28df10a80993/download/google_transit.zip' -O vvs.gtfs.zip
 unzip -d vvs-gtfs vvs.gtfs.zip
 
-# install generate-herrenberg-gtfs-flex as a development dependency
-npm install --save-dev derhuerst/generate-herrenberg-gtfs-flex
+# install generate-gtfs-flex as a development dependency
+npm install --save-dev derhuerst/generate-gtfs-flex
 
 # patch GTFS-Flex data into the VVS GTFS feed
 ./node_modules/.bin/generate-locations-geojson \
-	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
+	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
 	>vvs-gtfs/locations.geojson
 ./node_modules/.bin/generate-booking-rules-txt \
-	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
+	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/routes.txt \
 	>vvs-gtfs/booking_rules.txt
 ./node_modules/.bin/patch-trips-txt \
-	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
+	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
 	| sponge vvs-gtfs/trips.txt
 ./node_modules/.bin/patch-routes-txt \
-	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
+	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/routes.txt \
 	| sponge vvs-gtfs/routes.txt
 ./node_modules/.bin/patch-stop-times-txt \
-	node_modules/generate-herrenberg-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
+	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
 	vvs-gtfs/{routes,trips,stops,stop_times}.txt \
 	| sponge vvs-gtfs/stop_times.txt
 ```
 
-*pro tip:* If you install the package globally (via `npm install derhuerst/generate-herrenberg-gtfs-flex -g`), npm will put the scripts into your [`$PATH`](https://en.wikipedia.org/wiki/PATH_(variable)), so instead of running `./node_modules/.bin/…`, you'll be able to just use them as documented below.
+*pro tip:* If you install the package globally (via `npm install derhuerst/generate-gtfs-flex -g`), npm will put the scripts into your [`$PATH`](https://en.wikipedia.org/wiki/PATH_(variable)), so instead of running `./node_modules/.bin/…`, you'll be able to just use them as documented below.
 
 
 ## Usage
@@ -108,11 +108,11 @@ Examples:
         gtfs/{routes,trips,stops,stop_times}.txt >gtfs/stop_times.patched.txt
 ```
 
-*Note:* Currently, `generate-herrenberg-gtfs-flex` inserts all trips & `stop_times` rows affected by any of the rules *twice*: One on-demand trip stopping directly at the stops, one trip stopping at Flex areas.
+*Note:* Currently, `generate-gtfs-flex` inserts all trips & `stop_times` rows affected by any of the rules *twice*: One on-demand trip stopping directly at the stops, one trip stopping at Flex areas.
 
 ### with Docker
 
-You can use the [`derhuerst/generate-herrenberg-gtfs-flex` Docker image](https://hub.docker.com/r/derhuerst/generate-herrenberg-gtfs-flex). It will call the tools documented above on a GTFS feed that you mount into the container.
+You can use the [`derhuerst/generate-gtfs-flex` Docker image](https://hub.docker.com/r/derhuerst/generate-gtfs-flex). It will call the tools documented above on a GTFS feed that you mount into the container.
 
 - You need to specify the *rule file* (see above) to use, either a relative path to a bundled *rule file* or an absolute path to you own.
 - Optionally, you can pass the path of the GTFS directory (default is `/gtfs`).
@@ -121,11 +121,11 @@ You can use the [`derhuerst/generate-herrenberg-gtfs-flex` Docker image](https:/
 # with a bundled rule file
 docker run \
 	-v /path/to/gtfs:/gtfs \
-	--rm -it derhuerst/generate-herrenberg-gtfs-flex
+	--rm -it derhuerst/generate-gtfs-flex
 # with your own rule file & custom GTFS directory
 docker run \
 	-v $PWD:/cfg -v /path/to/my-gtfs:/my-gtfs \
-	--rm -it derhuerst/generate-herrenberg-gtfs-flex \
+	--rm -it derhuerst/generate-gtfs-flex \
 	/cfg/my-flex-rules.js /my-gtfs
 ```
 
@@ -137,11 +137,11 @@ docker run \
 You can use the scripts in this repo with *any* GTFS feed. As an example, we're going to patch [`sample-gtfs-feed`](https://github.com/public-transport/sample-gtfs-feed)'s `A` ("Ada Lovelace Bus Line") route to have flexible on-demand drop-offs.
 
 ```shell
-# as above, initialise an empty npm project & install generate-herrenberg-gtfs-flex
+# as above, initialise an empty npm project & install generate-gtfs-flex
 mkdir sample-gtfs-feed-with-flex
 cd sample-gtfs-feed-with-flex
 npm init --yes
-npm install --save-dev sample-gtfs-feed derhuerst/generate-herrenberg-gtfs-flex
+npm install --save-dev sample-gtfs-feed derhuerst/generate-gtfs-flex
 ```
 
 We're going to write a file `flex-rules.js` that exports a list of GTFS-Flex *rules*. Each of these rules is a function that must, when given a `routes.txt` entry/row, return either `null` to leave it unchanged or return a GTFS-Flex *spec* (check out [the schema](lib/flex-spec-schema.json)) to patch it:
@@ -200,4 +200,4 @@ cp -r node_modules/sample-gtfs-feed/gtfs gtfs
 
 ## Contributing
 
-If you have a question or need support using `generate-herrenberg-gtfs-flex`, please double-check your code and setup first. If you think you have found a bug or want to propose a feature, use [the issues page](https://github.com/derhuerst/generate-herrenberg-gtfs-flex/issues).
+If you have a question or need support using `generate-gtfs-flex`, please double-check your code and setup first. If you think you have found a bug or want to propose a feature, use [the issues page](https://github.com/derhuerst/generate-gtfs-flex/issues).

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ npm install --save-dev derhuerst/generate-gtfs-flex
 	>vvs-gtfs/locations.geojson
 ./node_modules/.bin/generate-booking-rules-txt \
 	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
-	vvs-gtfs/routes.txt \
+	vvs-gtfs/{routes,trips}.txt \
 	>vvs-gtfs/booking_rules.txt
 ./node_modules/.bin/patch-trips-txt \
 	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
@@ -57,7 +57,7 @@ npm install --save-dev derhuerst/generate-gtfs-flex
 	| sponge vvs-gtfs/trips.txt
 ./node_modules/.bin/patch-routes-txt \
 	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
-	vvs-gtfs/routes.txt \
+	vvs-gtfs/{routes,trips}.txt \
 	| sponge vvs-gtfs/routes.txt
 ./node_modules/.bin/patch-stop-times-txt \
 	node_modules/generate-gtfs-flex/stadtnavi-herrenberg-flex-rules.js \
@@ -184,10 +184,10 @@ cp -r node_modules/sample-gtfs-feed/gtfs gtfs
 	flex-rules.js gtfs/{routes,trips,stops,stop_times}.txt \
 	>gtfs/locations.geojson
 ./node_modules/.bin/generate-booking-rules-txt \
-	flex-rules.js gtfs/routes.txt \
+	flex-rules.js gtfs/{routes,trips}.txt \
 	>gtfs/booking_rules.txt
 ./node_modules/.bin/patch-routes-txt \
-	flex-rules.js gtfs/routes.txt \
+	flex-rules.js gtfs/{routes,trips}.txt \
 	| sponge gtfs/routes.txt
 ./node_modules/.bin/patch-trips-txt \
 	flex-rules.js gtfs/{routes,trips,stops,stop_times}.txt \

--- a/readme.md
+++ b/readme.md
@@ -106,10 +106,21 @@ Examples:
 
 ### with Docker
 
-You can use the [`derhuerst/generate-herrenberg-gtfs-flex` Docker image](https://hub.docker.com/r/derhuerst/generate-herrenberg-gtfs-flex). It will call the tools documented above on a GTFS feed that you mount into the container:
+You can use the [`derhuerst/generate-herrenberg-gtfs-flex` Docker image](https://hub.docker.com/r/derhuerst/generate-herrenberg-gtfs-flex). It will call the tools documented above on a GTFS feed that you mount into the container.
+
+- You need to specify the *rule file* (see above) to use, either a relative path to a bundled *rule file* or an absolute path to you own.
+- Optionally, you can pass the path of the GTFS directory (default is `/gtfs`).
 
 ```shell
-docker run -v /path/to/gtfs:/gtfs --rm -it derhuerst/generate-herrenberg-gtfs-flex
+# with a bundled rule file
+docker run \
+	-v /path/to/gtfs:/gtfs \
+	--rm -it derhuerst/generate-herrenberg-gtfs-flex
+# with your own rule file & custom GTFS directory
+docker run \
+	-v $PWD:/cfg -v /path/to/my-gtfs:/my-gtfs \
+	--rm -it derhuerst/generate-herrenberg-gtfs-flex \
+	/cfg/my-flex-rules.js /my-gtfs
 ```
 
 **⚠️ This will overwrite the original `routes.txt`, `trips.txt` & `stop_times.txt` files.**

--- a/stadtnavi-herrenberg-flex-rules.js
+++ b/stadtnavi-herrenberg-flex-rules.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// These are the GTFS-Flex patching rules used by Stadtnavi Herrenberg (https://herrenberg.stadtnavi.de).
+// see also https://github.com/mfdz/gtfs-hub/blob/d1338336ccecd884a727f7efe60fa4263513be6a/makefile#L105-L106
+
 const pickupTypes = require('gtfs-utils/pickup-types')
 const dropOffTypes = require('gtfs-utils/drop-off-types')
 const bookingTypes = require('gtfs-utils/booking-types')

--- a/stadtnavi-herrenberg-flex-rules.js
+++ b/stadtnavi-herrenberg-flex-rules.js
@@ -25,7 +25,7 @@ Haustürbedienung beim Absetzen 300m (Luftlinie) um die Haltestelle. Aufpreis 0,
 	},
 }
 const herrenbergCitybusRoutes = ['RT779', 'RT780', 'RT782', 'RT783']
-const herrenbergCitybus = (origRoute) => (
+const herrenbergCitybus = (origTrip, origRoute) => (
 	herrenbergCitybusRoutes.includes(origRoute.route_short_name)
 		? herrenbergCitybusFlex
 		: null
@@ -50,7 +50,7 @@ Haustürbeförderung beim Absetzen. Aufpreis 0,80€.`,
 	},
 }
 const regionalbusRoutes = ['RT753', 'RT773', 'RT775', 'RT791', 'RT794']
-const regionalbus = (origRoute) => (
+const regionalbus = (origTrip, origRoute) => (
 	// todo: add line-specific contact details
 	// todo: do all of these have drop-off at home?
 	regionalbusRoutes.includes(origRoute.route_short_name)

--- a/test/ada-lovelace-flexible-drop-off.js
+++ b/test/ada-lovelace-flexible-drop-off.js
@@ -4,7 +4,7 @@ const pickupTypes = require('gtfs-utils/pickup-types')
 const dropOffTypes = require('gtfs-utils/drop-off-types')
 const bookingTypes = require('gtfs-utils/booking-types')
 
-const adaLovelaceFlexibleDropOff = (route) => {
+const adaLovelaceFlexibleDropOff = (trip, route) => {
 	if (route.route_id !== 'A') return null // leave route unchanged
 	return {
 		id: 'A-flexible-drop-off', // ID of the GTFS-Flex spec


### PR DESCRIPTION
- [x] rename project from `generate-herrenberg-gtfs-flex` to `generate-gtfs-flex`
- [x] prepare project for >1 bundled rule file
- [x] make the *Haustürbedienung* (flexible drop off using `locations.geojson`) optional
- [x] change the flex rules to work trip-based instead of route-based
- [ ] write [bbnavi](https://bbnavi.de) (Berlin/Brandenburg cutout from DELFI GTFS) rule file (partially done)

Once this is done, we can adapt [`gtfs-hub`](https://github.com/mfdz/gtfs-hub) to use the new rule file in order to generate a GTFS Flex feed.